### PR TITLE
Fix Item Scroller trade list compatibility

### DIFF
--- a/src/main/java/net/ramixin/visibletraders/ducks/ClientMerchantMenuDuck.java
+++ b/src/main/java/net/ramixin/visibletraders/ducks/ClientMerchantMenuDuck.java
@@ -11,6 +11,10 @@ public interface ClientMerchantMenuDuck {
 
     void visibleTraders$enableCombinedOffers();
 
+    void visibleTraders$beginCombinedOffersScope();
+
+    void visibleTraders$endCombinedOffersScope();
+
     static ClientMerchantMenuDuck of(MerchantMenu screen) {
         return (ClientMerchantMenuDuck) screen;
     }

--- a/src/main/java/net/ramixin/visibletraders/mixins/client/MerchantMenuMixin.java
+++ b/src/main/java/net/ramixin/visibletraders/mixins/client/MerchantMenuMixin.java
@@ -1,6 +1,7 @@
 package net.ramixin.visibletraders.mixins.client;
 
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.world.inventory.MerchantMenu;
 import net.minecraft.world.item.trading.Merchant;
 import net.minecraft.world.item.trading.MerchantOffers;
@@ -11,7 +12,6 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
 
 import java.util.Optional;
 
@@ -28,6 +28,9 @@ public abstract class MerchantMenuMixin implements ClientMerchantMenuDuck {
     @Unique
     private boolean useCombinedOffers = false;
 
+    @Unique
+    private int combinedOffersScopeDepth = 0;
+
     @Override
     public void visibleTraders$setLockedTradeOffers(Optional<MerchantOffers> maybeOffers) {
         MerchantOffers combined = new MerchantOffers();
@@ -41,12 +44,25 @@ public abstract class MerchantMenuMixin implements ClientMerchantMenuDuck {
         useCombinedOffers = true;
     }
 
-    @ModifyReturnValue(method = "getOffers", at = @At("RETURN"))
-    private MerchantOffers useCombinedOffersIfEnabled(MerchantOffers original) {
+    @Override
+    public void visibleTraders$beginCombinedOffersScope() {
+        combinedOffersScopeDepth++;
+    }
+
+    @Override
+    public void visibleTraders$endCombinedOffersScope() {
+        combinedOffersScopeDepth = Math.max(0, combinedOffersScopeDepth - 1);
+    }
+
+    @WrapMethod(method = "getOffers")
+    private MerchantOffers useCombinedOffersIfEnabled(Operation<MerchantOffers> original) {
+        if(combinedOffersScopeDepth > 0 && combinedOffers.get() != null) {
+            return combinedOffers.get();
+        }
         if(useCombinedOffers && combinedOffers.get() != null) {
             useCombinedOffers = false;
             return combinedOffers.get();
         }
-        return original;
+        return original.call();
     }
 }

--- a/src/main/java/net/ramixin/visibletraders/mixins/client/TradeOfferButtonMixin.java
+++ b/src/main/java/net/ramixin/visibletraders/mixins/client/TradeOfferButtonMixin.java
@@ -1,22 +1,30 @@
 package net.ramixin.visibletraders.mixins.client;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.MerchantScreen;
-import net.minecraft.world.inventory.MerchantMenu;
-import net.minecraft.world.item.trading.MerchantOffers;
 import net.ramixin.visibletraders.ducks.ClientMerchantMenuDuck;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(MerchantScreen.TradeOfferButton.class)
 public class TradeOfferButtonMixin {
 
-    @WrapOperation(method = "extractToolTip", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/inventory/MerchantMenu;getOffers()Lnet/minecraft/world/item/trading/MerchantOffers;"))
-    private MerchantOffers enabledCombinedOffersForMouseDragged(MerchantMenu instance, Operation<MerchantOffers> original) {
-        ClientMerchantMenuDuck duck = (ClientMerchantMenuDuck) instance;
-        duck.visibleTraders$enableCombinedOffers();
-        return original.call(instance);
+    @Shadow
+    @Final
+    private MerchantScreen this$0;
+
+    @WrapMethod(method = "extractToolTip")
+    private void useCombinedOffersWhileExtractingTooltip(GuiGraphicsExtractor graphics, int mouseX, int mouseY, Operation<Void> original) {
+        ClientMerchantMenuDuck duck = (ClientMerchantMenuDuck) this.this$0.getMenu();
+        duck.visibleTraders$beginCombinedOffersScope();
+        try {
+            original.call(graphics, mouseX, mouseY);
+        } finally {
+            duck.visibleTraders$endCombinedOffersScope();
+        }
     }
 
 


### PR DESCRIPTION
Fixes #83.

## Problem

Item Scroller replaces `MerchantMenu#getOffers()` with a custom trade list using a cancellable `HEAD` injection. Visible Traders previously used `@ModifyReturnValue` at `RETURN`, so its combined unlocked + locked offer list was bypassed whenever Item Scroller returned early.

This also interacts with TweakerMore's `villagerOfferUsesDisplay` feature. TweakerMore reads the offer list from an injected tooltip path. Once Visible Traders rendered a button for a locked offer, TweakerMore could use that button index against Item Scroller's shorter list and crash with an `IndexOutOfBoundsException`.

## Fix

- Wrap the entire `MerchantMenu#getOffers()` method with MixinExtras `@WrapMethod`, so the combined list can be returned even when another injection cancels the original method.
- Add a nestable combined-offers scope to the client merchant menu.
- Wrap the entire `TradeOfferButton#extractToolTip` call in that scope and release it in `finally`. This ensures vanilla and injected tooltip code, including TweakerMore, see the same list for the full tooltip call.
- Keep ordinary calls outside the scope delegated to the original chain, preserving Item Scroller's normal favorites/reordering behavior and avoiding exposing locked indexes to actual trade submission.

## Validation

- In-game tested successfully on **Minecraft 26.1.2 Fabric** with:
  - Item Scroller 0.31.5
  - TweakerMore 3.31.0 with `villagerOfferUsesDisplay` enabled
  - Trade Cycling 1.0.21
- Locked/future trades render and can be hovered without crashing.
- Normal unlocked trades remain usable; locked trades remain inactive.
- Current `fabric` branch checks passed locally:
  - `compileJava`
  - `compileFabricJava`
  - `fabricJar`

The change has **not** been game-tested on Minecraft 26.2 or NeoForge.

## AI disclosure

The investigation and implementation were written with **OpenAI Codex using GPT-5.6 Sol with high reasoning effort**, followed by in-game validation on Minecraft 26.1.2 Fabric.
