### PR TITLE
Backport cartographer AIR trade fix to 1.21.1

### DIFF
--- a/backports/1.21.1-cartographer-fix/README.md
+++ b/backports/1.21.1-cartographer-fix/README.md
@@ -1,0 +1,33 @@
+# Visible Traders 1.21.1 cartographer AIR trade fix
+
+This directory contains a small backport patch for the published Fabric `1.3.2` build on Minecraft `1.21.1`.
+
+## Bug
+
+Cartographer explorer-map trades are generated asynchronously through `FutureMerchantOffer`. While pending, the placeholder offer uses `Items.AIR` as its input cost. Under some timing / null-result cases the placeholder can be promoted from locked trades into the villager's real vanilla `offers` list. The next entity save then fails because Minecraft 1.21.1 refuses to encode an AIR item cost:
+
+```
+java.lang.IllegalStateException: Item must not be minecraft:air
+```
+
+The issue reproduces by trading/levelling a cartographer and then saving/pausing the world.
+
+## Fix
+
+The patch keeps the existing asynchronous generation model but enforces two invariants:
+
+1. A future has a separate completion state, so a legitimate completed `null` explorer-map result is distinguishable from a still-pending lookup.
+2. `FutureMerchantOffer` placeholders are never promoted into vanilla villager offers. Completed futures are unwrapped to ordinary `MerchantOffer`s; completed-null results are omitted; pending futures keep the trade set locked.
+
+The completion flag is `volatile` so the server thread observes the resolved offer after the worker thread publishes completion.
+
+## Validation
+
+Built against:
+
+- Minecraft `1.21.1`
+- Fabric Loader `0.18.4`
+- Fabric API `0.116.7+1.21.1`
+- published Visible Traders `1.3.2` (`nEDGMR8b`)
+
+The resulting patched jar was tested in-game with the cartographer reproduction case and no longer crashes on save.

--- a/backports/1.21.1-cartographer-fix/build.gradle
+++ b/backports/1.21.1-cartographer-fix/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'fabric-loom' version '1.14.10'
+}
+
+version = '1.0.0'
+group = 'dev.idkwhodatis'
+
+base {
+    archivesName = 'visibletraders-cartographer-fix-patch'
+}
+
+repositories {
+    maven {
+        name = 'Modrinth'
+        url = 'https://api.modrinth.com/maven'
+    }
+}
+
+dependencies {
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings loom.officialMojangMappings()
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+    modImplementation "maven.modrinth:AhllI99f:${project.visible_traders_version}"
+}
+
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release.set(21)
+}

--- a/backports/1.21.1-cartographer-fix/gradle.properties
+++ b/backports/1.21.1-cartographer-fix/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=-Xmx2G
+minecraft_version=1.21.1
+loader_version=0.18.4
+fabric_api_version=0.116.7+1.21.1
+visible_traders_version=nEDGMR8b

--- a/backports/1.21.1-cartographer-fix/settings.gradle
+++ b/backports/1.21.1-cartographer-fix/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    repositories {
+        maven {
+            name = 'Fabric'
+            url = 'https://maven.fabricmc.net/'
+        }
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'visibletraders-cartographer-fix'

--- a/backports/1.21.1-cartographer-fix/src/main/java/dev/idkwhodatis/visibletradersfix/FutureMerchantOfferState.java
+++ b/backports/1.21.1-cartographer-fix/src/main/java/dev/idkwhodatis/visibletradersfix/FutureMerchantOfferState.java
@@ -1,0 +1,5 @@
+package dev.idkwhodatis.visibletradersfix;
+
+public interface FutureMerchantOfferState {
+    boolean visibleTradersFix$isCompleted();
+}

--- a/backports/1.21.1-cartographer-fix/src/main/java/dev/idkwhodatis/visibletradersfix/mixin/FutureMerchantOfferMixin.java
+++ b/backports/1.21.1-cartographer-fix/src/main/java/dev/idkwhodatis/visibletradersfix/mixin/FutureMerchantOfferMixin.java
@@ -1,0 +1,46 @@
+package dev.idkwhodatis.visibletradersfix.mixin;
+
+import dev.idkwhodatis.visibletradersfix.FutureMerchantOfferState;
+import net.minecraft.world.item.trading.MerchantOffer;
+import net.ramixin.visibletraders.VisibleTraders;
+import net.ramixin.visibletraders.threading.FutureMerchantOffer;
+import org.apache.commons.lang3.mutable.Mutable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.function.Supplier;
+
+@Mixin(value = FutureMerchantOffer.class, remap = false)
+public abstract class FutureMerchantOfferMixin implements FutureMerchantOfferState {
+
+    @Shadow @Final private Mutable<MerchantOffer> offer;
+    @Shadow @Final private Supplier<MerchantOffer> future;
+
+    @Unique
+    private volatile boolean visibleTradersFix$completed;
+
+    @Inject(method = "fulfillFuture", at = @At("HEAD"), cancellable = true, remap = false)
+    private void visibleTradersFix$fulfillSafely(CallbackInfo ci) {
+        try {
+            this.offer.setValue(this.future.get());
+        } catch (Throwable throwable) {
+            VisibleTraders.LOGGER.error("Failed to generate async villager trade; dropping the trade instead of leaving an invalid placeholder", throwable);
+            this.offer.setValue(null);
+        } finally {
+            // Volatile write publishes the resolved offer (including a legitimate null)
+            // to the server thread before it is allowed to unwrap the future.
+            this.visibleTradersFix$completed = true;
+        }
+        ci.cancel();
+    }
+
+    @Override
+    public boolean visibleTradersFix$isCompleted() {
+        return this.visibleTradersFix$completed;
+    }
+}

--- a/backports/1.21.1-cartographer-fix/src/main/java/dev/idkwhodatis/visibletradersfix/mixin/LockedTradeDataMixin.java
+++ b/backports/1.21.1-cartographer-fix/src/main/java/dev/idkwhodatis/visibletradersfix/mixin/LockedTradeDataMixin.java
@@ -1,0 +1,121 @@
+package dev.idkwhodatis.visibletradersfix.mixin;
+
+import dev.idkwhodatis.visibletradersfix.FutureMerchantOfferState;
+import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.item.trading.MerchantOffer;
+import net.minecraft.world.item.trading.MerchantOffers;
+import net.ramixin.visibletraders.LockedTradeData;
+import net.ramixin.visibletraders.VisibleTraders;
+import net.ramixin.visibletraders.threading.FutureMerchantOffer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Mixin(value = LockedTradeData.class, remap = false)
+public abstract class LockedTradeDataMixin {
+
+    @Shadow private List<MerchantOffers> lockedOffers;
+
+    @Shadow
+    private static ArrayList<MerchantOffers> generateTrades(Villager villager) {
+        throw new AssertionError();
+    }
+
+    @Unique
+    private MerchantOffers visibleTradersFix$normalize(MerchantOffers source, boolean keepPending) {
+        MerchantOffers normalized = new MerchantOffers();
+        for (MerchantOffer offer : source) {
+            if (!(offer instanceof FutureMerchantOffer futureOffer)) {
+                normalized.add(offer);
+                continue;
+            }
+
+            FutureMerchantOfferState state = (FutureMerchantOfferState) (Object) futureOffer;
+            if (!state.visibleTradersFix$isCompleted()) {
+                if (keepPending) {
+                    normalized.add(futureOffer);
+                    continue;
+                }
+                return null;
+            }
+
+            MerchantOffer resolved = futureOffer.getFuture();
+            if (resolved != null) normalized.add(resolved);
+            // A completed null result is valid for explorer-map lookups: simply omit it.
+        }
+        return normalized;
+    }
+
+    @Inject(method = "popTradeSet", at = @At("HEAD"), cancellable = true, remap = false)
+    private void visibleTradersFix$popOnlyResolved(CallbackInfoReturnable<MerchantOffers> cir) {
+        if (this.lockedOffers == null || this.lockedOffers.isEmpty()) {
+            cir.setReturnValue(null);
+            return;
+        }
+
+        MerchantOffers normalized = this.visibleTradersFix$normalize(this.lockedOffers.getFirst(), false);
+        if (normalized == null) {
+            // The next level still contains an async placeholder. Do not remove or expose it.
+            cir.setReturnValue(null);
+            return;
+        }
+
+        this.lockedOffers.removeFirst();
+        cir.setReturnValue(normalized);
+    }
+
+    @Inject(method = "peekTradeSet", at = @At("HEAD"), cancellable = true, remap = false)
+    private void visibleTradersFix$peekNormalized(CallbackInfoReturnable<Optional<MerchantOffers>> cir) {
+        if (this.lockedOffers == null || this.lockedOffers.isEmpty()) {
+            cir.setReturnValue(Optional.empty());
+            return;
+        }
+        cir.setReturnValue(Optional.of(this.visibleTradersFix$normalize(this.lockedOffers.getFirst(), true)));
+    }
+
+    @Inject(method = "buildLockedOffers", at = @At("HEAD"), cancellable = true, remap = false)
+    private void visibleTradersFix$buildNormalizedOffers(CallbackInfoReturnable<MerchantOffers> cir) {
+        MerchantOffers combined = new MerchantOffers();
+        if (this.lockedOffers == null) {
+            cir.setReturnValue(combined);
+            return;
+        }
+
+        for (MerchantOffers set : this.lockedOffers) {
+            combined.addAll(this.visibleTradersFix$normalize(set, true));
+        }
+        cir.setReturnValue(combined);
+    }
+
+    @Inject(method = "tick", at = @At("HEAD"), cancellable = true, remap = false)
+    private void visibleTradersFix$avoidUnresolvedPopLoop(Villager villager, Runnable popCallback, CallbackInfo ci) {
+        if (this.lockedOffers == null) {
+            ci.cancel();
+            return;
+        }
+
+        int requiredSets = 5 - villager.getVillagerData().getLevel();
+        while (requiredSets < this.lockedOffers.size()) {
+            int before = this.lockedOffers.size();
+            popCallback.run();
+            if (this.lockedOffers.size() == before) {
+                // popTradeSet refused because the first set is still generating.
+                break;
+            }
+        }
+
+        if (requiredSets > this.lockedOffers.size()) {
+            VisibleTraders.LOGGER.error("detected missing locked trade sets. Rebuilding locked offers");
+            this.lockedOffers = generateTrades(villager);
+        }
+        ci.cancel();
+    }
+}

--- a/backports/1.21.1-cartographer-fix/src/main/resources/visibletraders-cartographer-fix.mixins.json
+++ b/backports/1.21.1-cartographer-fix/src/main/resources/visibletraders-cartographer-fix.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "package": "dev.idkwhodatis.visibletradersfix.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "FutureMerchantOfferMixin",
+    "LockedTradeDataMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
This fixes a crash in Visible Traders 1.3.2 on Minecraft 1.21.1 when trading with cartographers.

The crash was caused by unresolved async cartographer trades using an AIR placeholder that could leak into the villager’s normal offers and later fail during NBT saving with Item must not be minecraft:air.

The fix:

tracks async trade completion separately from the returned offer,
prevents unresolved placeholders from entering vanilla villager offers,
unwraps completed futures into normal trades,
safely skips cartographer map trades that resolve to null.

Tested in-game with the previously crashing cartographer trade/save flow.